### PR TITLE
Stop opening link when clicking on ID

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ document.addEventListener('click', (e) => {
 
 	if (isCardShortId) {
 		e.stopImmediatePropagation();
+		e.preventDefault();
 
 		input.value = elem.textContent.replace('Nr. ', '#');
 		input.select();


### PR DESCRIPTION
This prevents the default card-link to open and refresh the page.